### PR TITLE
Phase 3: Telco intent + Agent readiness analyzers (#9 #10)

### DIFF
--- a/examples/telco-intent.json
+++ b/examples/telco-intent.json
@@ -1,0 +1,12 @@
+{
+  "service_name": "oai-upf-east",
+  "operator": "swisscom-lab",
+  "region": "eu-central",
+  "dnn": "internet",
+  "require_ipv4": true,
+  "latency_profile": "low",
+  "notes": {
+    "source": "transcript-grounded-demo",
+    "goal": "separate abstraction, validation, and provenance"
+  }
+}

--- a/src/shiftscope/analyzers/agent_readiness/__init__.py
+++ b/src/shiftscope/analyzers/agent_readiness/__init__.py
@@ -1,0 +1,5 @@
+"""Agent readiness analyzer — pilot→production migration."""
+
+from shiftscope.analyzers.agent_readiness.analyzer import AgentReadinessAnalyzer
+
+__all__ = ["AgentReadinessAnalyzer"]

--- a/src/shiftscope/analyzers/agent_readiness/analyzer.py
+++ b/src/shiftscope/analyzers/agent_readiness/analyzer.py
@@ -1,0 +1,70 @@
+"""Agent readiness analyzer — evaluates AI agent production readiness."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from shiftscope.analyzers.agent_readiness.rules import build_rules
+from shiftscope.core.analyzer import Analyzer
+from shiftscope.core.models import Report
+from shiftscope.core.rule import Rule
+
+
+class AgentReadinessAnalyzer(Analyzer):
+    """Evaluates AI agent configurations for production readiness."""
+
+    name = "agent-readiness"
+    version = "0.1.0"
+    description = "AI agent pilot→production readiness assessment"
+
+    def __init__(self) -> None:
+        self._rules = build_rules()
+
+    def analyze(self, input_path: str, **kwargs: Any) -> Report:
+        data = json.loads(Path(input_path).read_text(encoding="utf-8"))
+        context = dict(data)
+
+        # Compute scores for promotion gate
+        security = self._security_score(context)
+        observability = self._observability_score(context)
+        economics = self._economics_score(context)
+        context["security_score"] = security
+        context["observability_score"] = observability
+        context["economics_score"] = economics
+
+        findings = self.run_rules(context)
+        return Report(
+            analyzer_name=self.name,
+            analyzer_version=self.version,
+            source=input_path,
+            findings=findings,
+            metadata={"agent_name": data.get("agent_name", "")},
+        )
+
+    def list_rules(self) -> list[Rule]:
+        return list(self._rules)
+
+    @staticmethod
+    def _security_score(ctx: dict[str, Any]) -> float:
+        required = set(ctx.get("required_tools", []))
+        allowed = set(ctx.get("allowed_tools", []))
+        if not allowed:
+            return 0.0
+        denied = required - allowed
+        return 0.0 if denied else 1.0
+
+    @staticmethod
+    def _observability_score(ctx: dict[str, Any]) -> float:
+        if not ctx.get("otel_enabled", False):
+            return 0.0
+        return float(ctx.get("trace_coverage_ratio", 0.0))
+
+    @staticmethod
+    def _economics_score(ctx: dict[str, Any]) -> float:
+        limit = ctx.get("token_budget_limit", 0)
+        used = ctx.get("used_tokens", 0)
+        if limit <= 0:
+            return 0.0
+        return 1.0 if used <= limit else max(0.0, 1.0 - (used - limit) / limit)

--- a/src/shiftscope/analyzers/agent_readiness/rules.py
+++ b/src/shiftscope/analyzers/agent_readiness/rules.py
@@ -1,0 +1,131 @@
+"""Agent readiness rules — security, observability, token budget, promotion gate."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from shiftscope.core.models import Finding, Severity
+from shiftscope.core.rule import Rule
+
+_WEIGHTS = {"security": 0.4, "observability": 0.35, "economics": 0.25}
+_PROMOTE_THRESHOLD = 0.85
+_HOLD_THRESHOLD = 0.65
+
+
+class ToolAllowlistRule(Rule):
+    """Blocks agents that require tools not in the approved allowlist."""
+
+    rule_id = "agent-tool-allowlist"
+    severity = Severity.CRITICAL
+
+    def applies_to(self, context: dict[str, Any]) -> bool:
+        return "required_tools" in context and "allowed_tools" in context
+
+    def evaluate(self, context: dict[str, Any]) -> Finding | None:
+        required = set(context.get("required_tools", []))
+        allowed = set(context.get("allowed_tools", []))
+        denied = sorted(required - allowed)
+        if not denied:
+            return None
+        return Finding(
+            rule_id=self.rule_id,
+            severity=self.severity,
+            title=f"{len(denied)} tool(s) not in allowlist",
+            detail="Agent requires tools that are not in the approved allowlist. Promotion blocked.",
+            evidence=f"denied: {', '.join(denied)}",
+            recommendation="Remove denied tools or update the allowlist after security review.",
+        )
+
+
+class TokenBudgetRule(Rule):
+    """Flags agents exceeding their token budget."""
+
+    rule_id = "agent-token-budget"
+    severity = Severity.WARNING
+
+    def applies_to(self, context: dict[str, Any]) -> bool:
+        return "used_tokens" in context and "token_budget_limit" in context
+
+    def evaluate(self, context: dict[str, Any]) -> Finding | None:
+        used = context.get("used_tokens", 0)
+        limit = context.get("token_budget_limit", 0)
+        if limit <= 0 or used <= limit:
+            return None
+        overage = used - limit
+        return Finding(
+            rule_id=self.rule_id,
+            severity=self.severity,
+            title="Token budget exceeded",
+            detail=f"Agent used {used} tokens against a budget of {limit} ({overage} over).",
+            evidence=f"used={used}, limit={limit}, overage={overage}",
+            recommendation="Reduce token usage or increase budget after cost review.",
+        )
+
+
+class ObservabilityRule(Rule):
+    """Flags agents without proper observability (OTEL + trace coverage)."""
+
+    rule_id = "agent-observability"
+    severity = Severity.WARNING
+
+    def applies_to(self, context: dict[str, Any]) -> bool:
+        return "otel_enabled" in context
+
+    def evaluate(self, context: dict[str, Any]) -> Finding | None:
+        otel = context.get("otel_enabled", False)
+        coverage = context.get("trace_coverage_ratio", 0.0)
+        if otel and coverage >= 0.8:
+            return None
+        issues = []
+        if not otel:
+            issues.append("OTEL not enabled")
+        if coverage < 0.8:
+            issues.append(f"trace coverage {coverage:.0%} < 80%")
+        return Finding(
+            rule_id=self.rule_id,
+            severity=self.severity,
+            title="Observability gaps detected",
+            detail="Production agents require OTEL tracing with >=80% trace coverage.",
+            evidence=f"otel_enabled={otel}, trace_coverage={coverage:.0%}; issues: {', '.join(issues)}",
+            recommendation="Enable OTEL and ensure trace coverage >= 80% before promotion.",
+        )
+
+
+class PromotionGateRule(Rule):
+    """Combined promotion gate: security * 0.4 + observability * 0.35 + economics * 0.25."""
+
+    rule_id = "agent-promotion-gate"
+    severity = Severity.CRITICAL
+
+    def applies_to(self, context: dict[str, Any]) -> bool:
+        return all(
+            k in context for k in ("security_score", "observability_score", "economics_score")
+        )
+
+    def evaluate(self, context: dict[str, Any]) -> Finding | None:
+        sec = context.get("security_score", 0.0)
+        obs = context.get("observability_score", 0.0)
+        econ = context.get("economics_score", 0.0)
+        total = (
+            sec * _WEIGHTS["security"]
+            + obs * _WEIGHTS["observability"]
+            + econ * _WEIGHTS["economics"]
+        )
+
+        if total >= _PROMOTE_THRESHOLD:
+            return None
+
+        status = "hold" if total >= _HOLD_THRESHOLD else "block"
+        return Finding(
+            rule_id=self.rule_id,
+            severity=self.severity,
+            title=f"Promotion gate: {status}",
+            detail=f"Weighted score {total:.2f} < {_PROMOTE_THRESHOLD} threshold. "
+            f"Security={sec:.2f}, Observability={obs:.2f}, Economics={econ:.2f}.",
+            evidence=f"total={total:.2f}, status={status}",
+            recommendation="Improve the lowest-scoring dimension before re-evaluating.",
+        )
+
+
+def build_rules() -> list[Rule]:
+    return [ToolAllowlistRule(), TokenBudgetRule(), ObservabilityRule(), PromotionGateRule()]

--- a/src/shiftscope/analyzers/telco_intent/__init__.py
+++ b/src/shiftscope/analyzers/telco_intent/__init__.py
@@ -1,0 +1,5 @@
+"""Telco intent provenance analyzer — YANG→GitOps migration."""
+
+from shiftscope.analyzers.telco_intent.analyzer import TelcoIntentAnalyzer
+
+__all__ = ["TelcoIntentAnalyzer"]

--- a/src/shiftscope/analyzers/telco_intent/analyzer.py
+++ b/src/shiftscope/analyzers/telco_intent/analyzer.py
@@ -1,0 +1,48 @@
+"""Telco intent provenance analyzer."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from shiftscope.analyzers.telco_intent.rules import build_rules
+from shiftscope.core.analyzer import Analyzer
+from shiftscope.core.models import Report
+from shiftscope.core.rule import Rule
+
+
+class TelcoIntentAnalyzer(Analyzer):
+    """Analyzes telco intent configurations for GitOps migration readiness."""
+
+    name = "telco-intent"
+    version = "0.1.0"
+    description = "Telco YANG→GitOps intent provenance analysis"
+
+    def __init__(self) -> None:
+        self._rules = build_rules()
+
+    def analyze(self, input_path: str, **kwargs: Any) -> Report:
+        data = json.loads(Path(input_path).read_text(encoding="utf-8"))
+        context = {
+            "service_name": data.get("service_name", ""),
+            "operator": data.get("operator", ""),
+            "region": data.get("region", ""),
+            "dnn": data.get("dnn", ""),
+            "require_ipv4": data.get("require_ipv4", False),
+            "latency_profile": data.get("latency_profile", ""),
+            "gitops_target": data.get("notes", {}).get("gitops_target", "argocd"),
+            "southbound_target": data.get("notes", {}).get("southbound_target", "sdc"),
+            "has_hydration": bool(data.get("notes", {}).get("hydration")),
+        }
+        findings = self.run_rules(context)
+        return Report(
+            analyzer_name=self.name,
+            analyzer_version=self.version,
+            source=input_path,
+            findings=findings,
+            metadata={"service_name": context["service_name"], "operator": context["operator"]},
+        )
+
+    def list_rules(self) -> list[Rule]:
+        return list(self._rules)

--- a/src/shiftscope/analyzers/telco_intent/rules.py
+++ b/src/shiftscope/analyzers/telco_intent/rules.py
@@ -1,0 +1,84 @@
+"""Telco intent provenance rules."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from shiftscope.core.models import Finding, Severity
+from shiftscope.core.rule import Rule
+
+
+class GitOpsTargetRule(Rule):
+    """Flags Flux as GitOps target due to K8s version conflict with Nephio R6."""
+
+    rule_id = "telco-gitops-target"
+    severity = Severity.WARNING
+
+    def applies_to(self, context: dict[str, Any]) -> bool:
+        return "gitops_target" in context
+
+    def evaluate(self, context: dict[str, Any]) -> Finding | None:
+        target = context.get("gitops_target", "")
+        if target != "flux":
+            return None
+        return Finding(
+            rule_id=self.rule_id,
+            severity=self.severity,
+            title="Flux selected as GitOps target",
+            detail="Flux 2.8 K8s support starts at 1.33; Nephio R6 documented up to 1.32.0. Version mismatch risk.",
+            evidence=f"gitops_target=flux, region={context.get('region', '?')}",
+            recommendation="Use Argo CD as primary GitOps target; keep Flux as comparison only.",
+        )
+
+
+class ProvenanceReviewRule(Rule):
+    """Flags configurations that require human review due to hydrated data."""
+
+    rule_id = "telco-provenance-review"
+    severity = Severity.INFO
+
+    def applies_to(self, context: dict[str, Any]) -> bool:
+        return context.get("has_hydration", False) or context.get("require_ipv4", False)
+
+    def evaluate(self, context: dict[str, Any]) -> Finding | None:
+        if not context.get("has_hydration") and not context.get("require_ipv4"):
+            return None
+        parts = []
+        if context.get("has_hydration"):
+            parts.append("hydrated data present")
+        if context.get("require_ipv4"):
+            parts.append("IPv4 allocation required")
+        return Finding(
+            rule_id=self.rule_id,
+            severity=self.severity,
+            title="Provenance review required",
+            detail="Fields derived from hydration or IPAM allocation require human review before production deployment.",
+            evidence=", ".join(parts),
+            recommendation="Review provenance ledger and confirm all hydrated values before promotion.",
+        )
+
+
+class SouthboundContractRule(Rule):
+    """Notes that SDC southbound is contract-only, not a production CRD."""
+
+    rule_id = "telco-southbound-contract"
+    severity = Severity.INFO
+
+    def applies_to(self, context: dict[str, Any]) -> bool:
+        return context.get("southbound_target") == "sdc"
+
+    def evaluate(self, context: dict[str, Any]) -> Finding | None:
+        if context.get("southbound_target") != "sdc":
+            return None
+        return Finding(
+            rule_id=self.rule_id,
+            severity=self.severity,
+            title="SDC southbound is contract-only",
+            detail="SDC candidate payload is not an official CRD. Schema-aware validation adapter contract only.",
+            evidence="southbound_target=sdc",
+            recommendation="Do not treat rendered SDC payload as production-deployable without vendor validation.",
+        )
+
+
+def build_rules() -> list[Rule]:
+    return [GitOpsTargetRule(), ProvenanceReviewRule(), SouthboundContractRule()]

--- a/tests/analyzers/test_agent_readiness.py
+++ b/tests/analyzers/test_agent_readiness.py
@@ -1,0 +1,149 @@
+"""Tests for agent readiness analyzer."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from shiftscope.core.models import Report, Severity
+
+
+@pytest.fixture
+def analyzer():
+    from shiftscope.analyzers.agent_readiness.analyzer import AgentReadinessAnalyzer
+
+    return AgentReadinessAnalyzer()
+
+
+class TestAgentReadinessRules:
+    def test_tool_allowlist_violation(self, analyzer):
+        rule = next(r for r in analyzer.list_rules() if r.rule_id == "agent-tool-allowlist")
+        ctx = {
+            "agent_name": "test",
+            "required_tools": ["sum", "print_environment"],
+            "allowed_tools": ["sum", "ask_user"],
+        }
+        finding = rule.evaluate(ctx)
+        assert finding is not None
+        assert finding.severity == Severity.CRITICAL
+        assert "print_environment" in finding.evidence
+
+    def test_tool_allowlist_pass(self, analyzer):
+        rule = next(r for r in analyzer.list_rules() if r.rule_id == "agent-tool-allowlist")
+        ctx = {
+            "agent_name": "test",
+            "required_tools": ["sum"],
+            "allowed_tools": ["sum", "ask_user"],
+        }
+        assert rule.evaluate(ctx) is None
+
+    def test_token_budget_overrun(self, analyzer):
+        rule = next(r for r in analyzer.list_rules() if r.rule_id == "agent-token-budget")
+        ctx = {"agent_name": "test", "used_tokens": 60000, "token_budget_limit": 50000}
+        finding = rule.evaluate(ctx)
+        assert finding is not None
+        assert finding.severity == Severity.WARNING
+
+    def test_token_budget_ok(self, analyzer):
+        rule = next(r for r in analyzer.list_rules() if r.rule_id == "agent-token-budget")
+        ctx = {"agent_name": "test", "used_tokens": 10000, "token_budget_limit": 50000}
+        assert rule.evaluate(ctx) is None
+
+    def test_missing_otel(self, analyzer):
+        rule = next(r for r in analyzer.list_rules() if r.rule_id == "agent-observability")
+        ctx = {"agent_name": "test", "otel_enabled": False, "trace_coverage_ratio": 0.0}
+        finding = rule.evaluate(ctx)
+        assert finding is not None
+
+    def test_otel_ok(self, analyzer):
+        rule = next(r for r in analyzer.list_rules() if r.rule_id == "agent-observability")
+        ctx = {"agent_name": "test", "otel_enabled": True, "trace_coverage_ratio": 0.95}
+        assert rule.evaluate(ctx) is None
+
+    def test_promotion_blocked(self, analyzer):
+        rule = next(r for r in analyzer.list_rules() if r.rule_id == "agent-promotion-gate")
+        ctx = {
+            "agent_name": "test",
+            "security_score": 0.3,
+            "observability_score": 0.2,
+            "economics_score": 0.1,
+        }
+        finding = rule.evaluate(ctx)
+        assert finding is not None
+        assert finding.severity == Severity.CRITICAL
+        assert "block" in finding.evidence.lower()
+
+    def test_promotion_ready(self, analyzer):
+        rule = next(r for r in analyzer.list_rules() if r.rule_id == "agent-promotion-gate")
+        ctx = {
+            "agent_name": "test",
+            "security_score": 0.95,
+            "observability_score": 0.90,
+            "economics_score": 0.85,
+        }
+        assert rule.evaluate(ctx) is None
+
+
+class TestAgentReadinessAnalyzer:
+    def test_analyze_safe_agent(self, analyzer, tmp_path):
+        config = tmp_path / "safe.json"
+        config.write_text(
+            json.dumps(
+                {
+                    "agent_name": "safe-agent",
+                    "required_tools": ["sum"],
+                    "allowed_tools": ["sum", "ask_user"],
+                    "token_budget_limit": 50000,
+                    "used_tokens": 10000,
+                    "otel_enabled": True,
+                    "trace_coverage_ratio": 0.95,
+                }
+            )
+        )
+        report = analyzer.analyze(str(config))
+        assert isinstance(report, Report)
+        assert report.analyzer_name == "agent-readiness"
+        # Safe agent should have no critical findings
+        critical = [f for f in report.findings if f.severity == Severity.CRITICAL]
+        assert len(critical) == 0
+
+    def test_analyze_unsafe_agent(self, analyzer, tmp_path):
+        config = tmp_path / "unsafe.json"
+        config.write_text(
+            json.dumps(
+                {
+                    "agent_name": "unsafe-agent",
+                    "required_tools": ["sum", "print_environment", "exec_shell"],
+                    "allowed_tools": ["sum"],
+                    "token_budget_limit": 50000,
+                    "used_tokens": 80000,
+                    "otel_enabled": False,
+                    "trace_coverage_ratio": 0.0,
+                }
+            )
+        )
+        report = analyzer.analyze(str(config))
+        assert len(report.findings) >= 2
+
+    def test_list_rules_count(self, analyzer):
+        assert len(analyzer.list_rules()) >= 4
+
+    def test_json_roundtrip(self, analyzer, tmp_path):
+        config = tmp_path / "test.json"
+        config.write_text(
+            json.dumps(
+                {
+                    "agent_name": "test",
+                    "required_tools": ["sum"],
+                    "allowed_tools": ["sum"],
+                    "token_budget_limit": 50000,
+                    "used_tokens": 10000,
+                    "otel_enabled": True,
+                    "trace_coverage_ratio": 0.9,
+                }
+            )
+        )
+        report = analyzer.analyze(str(config))
+        restored = Report.model_validate_json(report.model_dump_json())
+        assert len(restored.findings) == len(report.findings)

--- a/tests/analyzers/test_telco_intent.py
+++ b/tests/analyzers/test_telco_intent.py
@@ -1,0 +1,68 @@
+"""Tests for telco intent provenance analyzer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from shiftscope.core.models import Report, Severity
+
+EXAMPLES_DIR = Path(__file__).resolve().parents[2] / "examples"
+SAMPLE_INTENT = EXAMPLES_DIR / "telco-intent.json"
+
+
+@pytest.fixture
+def analyzer():
+    from shiftscope.analyzers.telco_intent.analyzer import TelcoIntentAnalyzer
+
+    return TelcoIntentAnalyzer()
+
+
+class TestTelcoRules:
+    def test_gitops_target_validation(self, analyzer):
+        rule = next(r for r in analyzer.list_rules() if r.rule_id == "telco-gitops-target")
+        ctx = {"gitops_target": "flux", "region": "eu-central"}
+        finding = rule.evaluate(ctx)
+        assert finding is not None
+        assert finding.severity == Severity.WARNING
+        assert "flux" in finding.evidence.lower() or "Flux" in finding.detail
+
+    def test_gitops_argocd_no_finding(self, analyzer):
+        rule = next(r for r in analyzer.list_rules() if r.rule_id == "telco-gitops-target")
+        ctx = {"gitops_target": "argocd", "region": "eu-central"}
+        assert rule.evaluate(ctx) is None
+
+    def test_provenance_review_required(self, analyzer):
+        rule = next(r for r in analyzer.list_rules() if r.rule_id == "telco-provenance-review")
+        ctx = {"require_ipv4": True, "has_hydration": True}
+        finding = rule.evaluate(ctx)
+        assert finding is not None
+
+    def test_no_hydration_no_provenance_finding(self, analyzer):
+        rule = next(r for r in analyzer.list_rules() if r.rule_id == "telco-provenance-review")
+        ctx = {"require_ipv4": False, "has_hydration": False}
+        assert rule.evaluate(ctx) is None
+
+    def test_southbound_contract_only(self, analyzer):
+        rule = next(r for r in analyzer.list_rules() if r.rule_id == "telco-southbound-contract")
+        ctx = {"southbound_target": "sdc"}
+        finding = rule.evaluate(ctx)
+        assert finding is not None
+        assert finding.severity == Severity.INFO
+
+
+class TestTelcoIntentAnalyzer:
+    def test_analyze_sample_intent(self, analyzer):
+        report = analyzer.analyze(str(SAMPLE_INTENT))
+        assert isinstance(report, Report)
+        assert report.analyzer_name == "telco-intent"
+        assert len(report.findings) >= 1
+
+    def test_list_rules_count(self, analyzer):
+        assert len(analyzer.list_rules()) >= 3
+
+    def test_json_roundtrip(self, analyzer):
+        report = analyzer.analyze(str(SAMPLE_INTENT))
+        restored = Report.model_validate_json(report.model_dump_json())
+        assert len(restored.findings) == len(report.findings)


### PR DESCRIPTION
## Summary
Two new analyzers ported from KubeCon EU 2026 prototype projects:

**Telco Intent** (3 rules): GitOps target validation (Flux/Nephio conflict),
provenance review (hydration fields), SDC southbound contract-only warning.

**Agent Readiness** (4 rules): Tool allowlist compliance, token budget
enforcement, observability gating (OTEL + trace coverage), weighted
promotion gate (security 0.4 + observability 0.35 + economics 0.25).

| Metric | Before | After |
|--------|--------|-------|
| Analyzers | 3 | 5 |
| Rules | 19 | 26 |
| Tests | 124 | 144 |

## Test plan
- [x] 20 new tests (8 telco + 12 agent readiness)
- [x] TDD: all tests written before implementation
- [x] Lint clean (ruff check + format)